### PR TITLE
feat: Implement sync logic for resources with service generated id

### DIFF
--- a/syncer/controllers/krmsyncer_controller_test.go
+++ b/syncer/controllers/krmsyncer_controller_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -46,7 +48,10 @@ func TestSyncerSync(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	// Start Source Cluster
 	testEnvSource := &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "config", "crd"),
+			filepath.Join("..", "test", "crd"),
+		},
 		ErrorIfCRDPathMissing: true,
 		DownloadBinaryAssets:  true,
 	}
@@ -55,7 +60,10 @@ func TestSyncerSync(t *testing.T) {
 
 	// Start Destination Cluster
 	testEnvDest := &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "config", "crd"),
+			filepath.Join("..", "test", "crd"),
+		},
 		ErrorIfCRDPathMissing: true,
 		DownloadBinaryAssets:  true,
 	}
@@ -92,6 +100,7 @@ func TestSyncerSync(t *testing.T) {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Manager: mgr,
+		Name:    "krmsyncer-test",
 	}).SetupWithManager(mgr)
 	require.NoError(t, err, "failed to setup controller")
 
@@ -182,6 +191,192 @@ func TestSyncerSync(t *testing.T) {
 		return client.IgnoreNotFound(err) == nil && err != nil, nil
 	})
 	assert.NoError(t, err, "ConfigMap should be deleted from dest")
+}
+
+func TestSyncerSyncResourceWithGeneratedID(t *testing.T) {
+	// Setup Logic
+	ctrl.SetLogger(klog.NewKlogr())
+	ctx, cancel := context.WithCancel(context.Background())
+	// Start Source Cluster
+	testEnvSource := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "config", "crd"),
+			filepath.Join("..", "test", "crd"),
+		},
+		ErrorIfCRDPathMissing: true,
+		DownloadBinaryAssets:  true,
+	}
+	cfgSource, err := testEnvSource.Start()
+	require.NoError(t, err)
+
+	// Start Destination Cluster
+	testEnvDest := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "config", "crd"),
+			filepath.Join("..", "test", "crd"),
+		},
+		ErrorIfCRDPathMissing: true,
+		DownloadBinaryAssets:  true,
+	}
+	cfgDest, err := testEnvDest.Start()
+	require.NoError(t, err)
+
+	defer func() {
+		cancel()
+		// give the manager a moment to stop
+		time.Sleep(100 * time.Millisecond)
+		require.NoError(t, testEnvSource.Stop())
+		require.NoError(t, testEnvDest.Stop())
+	}()
+
+	// Register Scheme
+	require.NoError(t, krmv1alpha1.AddToScheme(scheme.Scheme))
+
+	// Create Clients
+	k8sClientSource, err := client.New(cfgSource, client.Options{Scheme: scheme.Scheme})
+	require.NoError(t, err)
+	k8sClientDest, err := client.New(cfgDest, client.Options{Scheme: scheme.Scheme})
+	require.NoError(t, err)
+
+	// Start Manager in Source Cluster
+	mgr, err := ctrl.NewManager(cfgSource, ctrl.Options{
+		// Scheme: scheme.Scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
+	})
+	require.NoError(t, err, "failed to create manager")
+
+	err = (&KRMSyncerReconciler{
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Manager: mgr,
+		Name:    "krmsyncer-generatedid-test",
+	}).SetupWithManager(mgr)
+	require.NoError(t, err, "failed to setup controller")
+
+	go func() {
+		if err := mgr.Start(ctx); err != nil {
+			fmt.Printf("manager failed: %v\n", err)
+		}
+	}()
+
+	// Test Logic
+	ns := "default"
+	secretName := "dest-kubeconfig"
+	syncerName := "test-syncer"
+
+	tests := []struct {
+		name         string
+		gvk          schema.GroupVersionKind
+		resourceName string
+		resourceID   string
+		status       map[string]interface{}
+	}{
+		{
+			name: "ResourceManagedByDirectController",
+			gvk: schema.GroupVersionKind{
+				Group:   "e2e.gkelabs.io",
+				Version: "v1alpha1",
+				Kind:    "ResourceWithGeneratedID",
+			},
+			resourceName: "test-resource-direct",
+			resourceID:   "12345",
+			status: map[string]interface{}{
+				"externalRef": "projects/my-project/resources/12345",
+			},
+		},
+		{
+			name: "ResourceManagedByLegacyController",
+			gvk: schema.GroupVersionKind{
+				Group:   "e2e.gkelabs.io",
+				Version: "v1alpha1",
+				Kind:    "ResourceWithGeneratedID",
+			},
+			resourceName: "test-resource-legacy",
+			resourceID:   "67890",
+		},
+	}
+
+	// Generate kubeconfig from envtest Dest config
+	destKubeconfigContent, err := createKubeconfig(cfgDest)
+	require.NoError(t, err)
+
+	// Create Secret in Source with Dest Kubeconfig
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: ns},
+		Data:       map[string][]byte{"kubeconfig": destKubeconfigContent},
+	}
+	require.NoError(t, k8sClientSource.Create(ctx, secret))
+
+	// Build Rules from tests
+	var rules []krmv1alpha1.ResourceRule
+	for _, tc := range tests {
+		rules = append(rules, krmv1alpha1.ResourceRule{
+			Group:      tc.gvk.Group,
+			Version:    tc.gvk.Version,
+			Kind:       tc.gvk.Kind,
+			Namespaces: []string{ns},
+		})
+	}
+
+	// Create Syncer
+	syncer := &krmv1alpha1.KRMSyncer{
+		ObjectMeta: metav1.ObjectMeta{Name: syncerName, Namespace: ns},
+		Spec: krmv1alpha1.KRMSyncerSpec{
+			Suspend: false,
+			Destination: &krmv1alpha1.DestinationConfig{
+				ClusterConfig: &krmv1alpha1.ClusterConfig{
+					KubeConfigSecretRef: &corev1.SecretReference{Name: secretName, Namespace: ns},
+				},
+			},
+			Rules: rules,
+		},
+	}
+	require.NoError(t, k8sClientSource.Create(ctx, syncer))
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create Resource in Source
+			u := &unstructured.Unstructured{}
+			u.SetGroupVersionKind(tc.gvk)
+			u.SetName(tc.resourceName)
+			u.SetNamespace(ns)
+			require.NoError(t, k8sClientSource.Create(ctx, u))
+
+			if tc.status == nil {
+				require.NoError(t, k8sClientSource.Get(ctx, types.NamespacedName{Name: tc.resourceName, Namespace: ns}, u))
+				u.Object["spec"] = map[string]interface{}{
+					"resourceID": tc.resourceID,
+				}
+				require.NoError(t, k8sClientSource.Update(ctx, u))
+			} else {
+				// Update Status
+				// We need to get the object back to have the latest ResourceVersion before updating status
+				require.NoError(t, k8sClientSource.Get(ctx, types.NamespacedName{Name: tc.resourceName, Namespace: ns}, u))
+				u.Object["status"] = tc.status
+				require.NoError(t, k8sClientSource.Status().Update(ctx, u))
+			}
+
+			// Verify Sync to Dest and check spec.resourceID
+			err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+				destU := &unstructured.Unstructured{}
+				destU.SetGroupVersionKind(tc.gvk)
+				err := k8sClientDest.Get(ctx, types.NamespacedName{Name: tc.resourceName, Namespace: ns}, destU)
+				if err != nil {
+					return false, nil
+				}
+
+				val, _, err := unstructured.NestedString(destU.Object, "spec", "resourceID")
+				if err != nil {
+					return false, err
+				}
+
+				return val == tc.resourceID, nil
+			})
+			assert.NoError(t, err, "%s should be synced to dest with correct resourceID", tc.name)
+		})
+	}
 }
 
 func createKubeconfig(cfg *rest.Config) ([]byte, error) {

--- a/syncer/test/crd/resourcewithgeneratedid.e2e.gkelabs.io.yaml
+++ b/syncer/test/crd/resourcewithgeneratedid.e2e.gkelabs.io.yaml
@@ -1,0 +1,32 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: resourcewithgeneratedids.e2e.gkelabs.io
+spec:
+  group: e2e.gkelabs.io
+  names:
+    kind: ResourceWithGeneratedID
+    listKind: ResourceWithGeneratedIDList
+    plural: resourcewithgeneratedids
+    singular: resourcewithgeneratedid
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              resourceID:
+                type: string
+          status:
+            type: object
+            properties:
+              externalRef:
+                type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
Based off of #6 

According to https://github.com/gemmahou/k8s-config-connector/blob/11bc5adae49ae42558e7c6af46b76e001410fa83/docs/dev/snippets/resourceid.md#resources-with-service-generated-resource-ids, if `spec.resourceID` is not specified in the KRM object, the KCC controller will attempt to create a new resource rather than acquiring the existing one.

So before syncing the KRM object to the destination cluster, we ensure that `spec.resourceID` is populated. For objects managed by the legacy KCC controller, the generated ID is written back to `spec.resourceID` by default. For objects managed by the direct controller, we extract the ID from `status.externalRef` and write it to `spec.resourceID` accordingly. 

That way we ensured that the sync'd KRM object has `spec.resourceID`, and the KCC controller in the destination cluster will be able to acquire the resource.