### PR TITLE
fix: remove finalizers before syncing

### DIFF
--- a/syncer/controllers/krmsyncer_controller.go
+++ b/syncer/controllers/krmsyncer_controller.go
@@ -157,6 +157,8 @@ func (r *DynamicResourceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		} else {
 			return ctrl.Result{}, err
 		}
+	} else if u.GetDeletionTimestamp() != nil {
+		isDeleted = true
 	}
 
 	// Fetch all Syncers to find matching rules (Active ones)
@@ -212,6 +214,7 @@ func (r *DynamicResourceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 						logger.Error(err, "Failed to delete resource on remote cluster")
 					}
 				}
+				logger.Info("Successfully deleted resource on remote cluster", "name", req.Name, "namespace", req.Namespace)
 				continue
 			}
 
@@ -224,6 +227,7 @@ func (r *DynamicResourceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			remoteObj.SetUID("")
 			remoteObj.SetGeneration(0)
 			remoteObj.SetManagedFields(nil)
+			remoteObj.SetFinalizers(nil)
 
 			if err := r.applyToRemote(ctx, remoteClient, remoteObj); err != nil {
 				// TODO: report failure in syncer status


### PR DESCRIPTION
Do not sync to-be-deleted resources, mark it as "isDeleted" once deletionTimestamp is set. 

Error message: xxx is invalid: metadata.finalizers: Forbidden: no new finalizers can be added if the object is being deleted, found new finalizers cnrm.cloud.google.com/deletion-defender

The edge case:  e.g.  The controller is trying to use Patch (Apply) to sync an object that had already started its deletion process (deletionTimestamp is set, but deletion-defender finalizer is not removed yet)

Also cleanup finalizers before syncing to avoid issues during Patch.